### PR TITLE
[UNIVERSITY] Add additional facets list settings for filtering by microsites

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -8,13 +8,18 @@ from .search_engine_base import SearchEngine
 from .result_processor import SearchResultProcessor
 from .utils import DateRange
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 # Default filters that we support, override using COURSE_DISCOVERY_FILTERS setting if desired
 DEFAULT_FILTER_FIELDS = ["org", "modes", "language"]
 
 
 def course_discovery_filter_fields():
     """ look up the desired list of course discovery filter fields """
-    return getattr(settings, "COURSE_DISCOVERY_FILTERS", DEFAULT_FILTER_FIELDS)
+    return configuration_helpers.get_value(
+        "COURSE_DISCOVERY_FILTERS",
+        getattr(settings, "COURSE_DISCOVERY_FILTERS", DEFAULT_FILTER_FIELDS)
+    )
 
 
 def course_discovery_facets():


### PR DESCRIPTION
**Description:**
- Add reading from configuration helpers (micosite settings) for facets list (ex. `["org", "modes", "language"]`)
- Add possibility for overriding facets list for each microsite.

**YouTrack:**
[OP-105](https://youtrack.raccoongang.com/issue/OP-105)

**Settings:**
- Override `edx-search=1.2.1` into requirements to rg version with this commit.
- Add needed fields to the platform by additional development
- Add to microsite needed values (ex. `"COURSE_DISCOVERY_FILTERS":["topic", "level", "price", "process_type"]`)
